### PR TITLE
feat: Improve graph visualization

### DIFF
--- a/playground/script.js
+++ b/playground/script.js
@@ -442,7 +442,7 @@ document.addEventListener('DOMContentLoaded', function() {
         // Arrow marker
         const defs = svg.append('defs');
         defs.append('marker').attr('id', 'arrow').attr('viewBox', '0 -5 10 10')
-            .attr('refX', 15).attr('refY', 0).attr('markerWidth', 6).attr('markerHeight', 6)
+            .attr('refX', 18).attr('refY', 0).attr('markerWidth', 6).attr('markerHeight', 6)
             .attr('orient', 'auto')
           .append('path').attr('d', 'M0,-5L10,0L0,5').attr('fill', '#999');
 
@@ -467,12 +467,19 @@ document.addEventListener('DOMContentLoaded', function() {
         // Draw nodes
         const node = g.append('g').attr('class', 'nodes').selectAll('g')
             .data(nodes).enter().append('g').attr('class', 'node')
-            .call(d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended));
+            .call(d3.drag().on('start', dragstarted).on('drag', dragged).on('end', dragended))
+            .on('mouseover', function (event, d) {
+                d3.select(this).select('circle').transition().duration(150).attr('r', 18);
+            })
+            .on('mouseout', function (event, d) {
+                d3.select(this).select('circle').transition().duration(150).attr('r', 12);
+            });
         node.append('circle').attr('r', 12).attr('fill', d => assignedColors[d.type] || assignedColors.default)
             .attr('stroke', d => d.isMerge ? '#37474f' : 'none').attr('stroke-width', d => d.isMerge ? 3 : 0);
         node.append('text').text(d => d.label)
-            .attr('x', 0).attr('y', 16).attr('text-anchor', 'middle')
-            .attr('font-size', '12px').attr('fill', '#37474f');
+            .attr('x', 0).attr('y', 4).attr('text-anchor', 'middle')
+            .attr('font-size', '10px').attr('fill', 'white') // Adjusted font size slightly for better fit
+            .style('pointer-events', 'none'); // Ensure text doesn't interfere with mouse events on circle
 
         simulation.on('tick', () => {
             link.attr('d', d => `M${d.source.x},${d.source.y}L${d.target.x},${d.target.y}`);

--- a/playground/style.css
+++ b/playground/style.css
@@ -672,4 +672,9 @@ footer a:hover {
     opacity: 0.5;
     text-decoration: line-through;
     cursor: pointer; /* Maintain pointer cursor */
-} 
+}
+
+/* Change cursor to pointer on node hover */
+.graph-container g.node:hover {
+    cursor: pointer;
+}


### PR DESCRIPTION
This commit enhances the D3.js graph visualization in the playground:

1.  **Node Hover Effect**: Nodes now increase in size (radius from 12 to 18) upon mouse hover, providing better visual feedback. The cursor also changes to a pointer.
2.  **Improved Node Labels**: Node labels are now positioned inside the node circles (vertically centered with y=4) and rendered in white with a 10px font size for improved readability and a cleaner look. `pointer-events: none` is set on labels to ensure hover effects on nodes work correctly.
3.  **Edge Arrowheads**: The `refX` attribute for arrow markers on edges has been adjusted from 15 to 18 to better align with the node radius, preventing overlap.

These changes address the issue of improving the overall graph visualization by making relationships clearer, enhancing interactivity, and refining the presentation of node information.